### PR TITLE
[MIP-4] Give DAO members in discord a role that reflects their role in the DAO

### DIFF
--- a/proposals/mip-4.md
+++ b/proposals/mip-4.md
@@ -1,0 +1,26 @@
+# Menace Improvement Proposal (MIP-4)
+
+## tl;dr
+Give DAO members roles in discord that reflect our role in the DAO
+
+## What would be the roles?
+- Software 
+- Governance
+- Artists/Creators
+- BizDev
+- Marketing/Social/Community
+- Design/Frontend
+- Investor/fund management/back of the office/Bookkeeping
+
+Please comment below if you think that there should be more roles
+
+## Motivation
+We currently don't have a good idea of who does what in the DAO, it would be nice to have explicit roles, that maybe in the future when you get onboarded you can choose your role, and it'll assign you to guilds.
+
+## Owners
+List folks who are going to **owners** for the project and be responsible for delivering
+July, and anyone else who's interested
+
+## Resources
+Do you need funding? Do the contributors to making this improvement need to be paid in NFTs or FTM?
+- Nope


### PR DESCRIPTION
# What change does this introduce?
status: draft

## Description
<!--- tl;dr of summary of what is proposal is being proposed --->
- currently we don't know who does what in the DAO
- it would be nice if we could self select roles to choose in discord
- Here is the [Full proposal](https://github.com/FantomMenaceDAO/MIPs/blob/MIP-4/proposals/mip-4.md)